### PR TITLE
Small updates for running cassandra container and create keyspace and table statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,7 @@ project/plugins/project/
 .scala_dependencies
 .worksheet
 
+#IntelliJ-IDE specific
+.idea
+
 data

--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ docker exec -it cassandra cqlsh
 Then, in `cqlsh` you create an `akka_streams` keyspace:
 
 ```cql
-CREATE KEYSPACE akka_streams WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 3 };
+CREATE KEYSPACE akka_streams WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : '1' };
 ```
 
 Finally, let's create the `readings` table:
 
 ```cql
-CREATE TABLE readings (id int PRIMARY KEY, value float);  
+CREATE TABLE akka_streams.readings (id int PRIMARY KEY, value float);  
 ```
 
 # Running

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ docker run -d --name cassandra cassandra
 
 and in a while you should have Cassandra ready at port 9042. When the container has started, it's time to create a keyspace and a table for our data.
 
+Depending on the setup that you have you have you might want to bind the container directly to port 9042:
+```bash
+docker run --name cassandra -p 127.0.0.1:9042:9042 -d cassandra
+```
+
 First you need to run the CQL shell:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ docker exec -it cassandra cqlsh
 Then, in `cqlsh` you create an `akka_streams` keyspace:
 
 ```cql
-CREATE KEYSPACE akka_streams WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : '1' };
+CREATE KEYSPACE akka_streams WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
 ```
 
 Finally, let's create the `readings` table:


### PR DESCRIPTION
- added .idea directory to .gitignore
- added info how to bind docker container to 9042 port on localhost (mac)
- updated replication factor for keyspace to 1 because 3 is ignored by cassandra anyway in the examples
- updated create table statement to use keyspace (use statement is skipped so have to prefix create)